### PR TITLE
Run `terraform fmt --recursive` to format `.tf` files

### DIFF
--- a/examples/standard/main.tf
+++ b/examples/standard/main.tf
@@ -24,14 +24,14 @@ terraform {
   required_providers {
     google = {
       version = "~> 3.58"
-      source = "hashicorp/google"
+      source  = "hashicorp/google"
     }
   }
 }
 
 # Install the GitLab CI Runner infrastructure
 module "ci" {
-  source  = "../../"
+  source = "../../"
 
   gcp_project         = var.gcp_project
   gcp_zone            = var.gcp_zone
@@ -46,6 +46,6 @@ module "ci" {
 module "ci-privileges" {
   source = "./modules/gitlab-ci-privileges"
 
-  gcp_project = var.gcp_project
+  gcp_project               = var.gcp_project
   ci_worker_service_account = module.ci.ci_worker_service_account.email
 }

--- a/examples/standard/terraform.tfvars
+++ b/examples/standard/terraform.tfvars
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-gcp_zone    = "australia-southeast1-a"
+gcp_zone = "australia-southeast1-a"
 
 ci_concurrency      = 5
 ci_worker_idle_time = 3600

--- a/examples/standard/variables.tf
+++ b/examples/standard/variables.tf
@@ -15,26 +15,26 @@
  */
 
 variable "gcp_project" {
-    type        = string
-    description = "The GCP project to deploy the runner into."
+  type        = string
+  description = "The GCP project to deploy the runner into."
 }
 variable "gcp_zone" {
-    type        = string
-    description = "The GCP zone to deploy the runner into."
+  type        = string
+  description = "The GCP zone to deploy the runner into."
 }
 variable "gitlab_url" {
-    type        = string
-    description = "The URL of the GitLab server to register the runner against."
+  type        = string
+  description = "The URL of the GitLab server to register the runner against."
 }
 variable "ci_token" {
-    type        = string
-    description = "The runner registration token obtained from GitLab."
+  type        = string
+  description = "The runner registration token obtained from GitLab."
 }
 variable "ci_concurrency" {
-    type        = number
-    description = "The maximum number of concurrent worker instances to create."
+  type        = number
+  description = "The maximum number of concurrent worker instances to create."
 }
 variable "ci_worker_idle_time" {
-    type        = number
-    description = "The maximum idle time for workers before they are shutdown."
+  type        = number
+  description = "The maximum idle time for workers before they are shutdown."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -32,8 +32,8 @@ variable "gitlab_url" {
   description = "The URL of the GitLab server hosting the projects to be built."
 }
 variable "gcp_resource_prefix" {
-  type    = string
-  default = "gitlab-ci"
+  type        = string
+  default     = "gitlab-ci"
   description = "The prefix to apply to all GCP resource names (e.g. <prefix>-runner, <prefix>-worker-1)."
 }
 
@@ -49,14 +49,14 @@ variable "ci_runner_gitlab_name" {
   description = "Register the runner in GitLab using this name.  If empty the value \"gcp-$${var.gcp_project}\" will be used."
 }
 variable "ci_runner_gitlab_tags" {
-    type        = string
-    default     = ""
-    description = "Register the runner to execute GitLab jobs with these tags."
+  type        = string
+  default     = ""
+  description = "Register the runner to execute GitLab jobs with these tags."
 }
 variable "ci_runner_gitlab_untagged" {
-    type        = string
-    default     = "true"
-    description = "Register the runner to also execute GitLab jobs that are untagged."
+  type        = string
+  default     = "true"
+  description = "Register the runner to also execute GitLab jobs that are untagged."
 }
 variable "ci_runner_instance_type" {
   type        = string


### PR DESCRIPTION
I tend to run `terraform fmt --recursive` as part of my workflow prior to pushing changes. When this repo is used as a submodule in other repos the end result is unintended changes to the this repo (submodule). This, and the subsequent submodule update in the parent repo, fixes this and has no other material impact.